### PR TITLE
Update optional-requirements.txt -> increase lxml requirement

### DIFF
--- a/optional-requirements.txt
+++ b/optional-requirements.txt
@@ -15,6 +15,6 @@ six==1.10.0
 goodreads>=0.3.2
 python-Levenshtein>=0.12.0
 # other
-lxml==3.7.2
+lxml>=3.8.0
 rarfile>=2.7
 natsort>=2.2.0


### PR DESCRIPTION
changed optional requirement from lxml==3.7.2 to >=3.8.0 ebook-convert is not working properly with a version < 3.8.0